### PR TITLE
Feature/alpen#104/payment

### DIFF
--- a/html/mycakeapp/config/Migrations/20210215015016_CreatePayments.php
+++ b/html/mycakeapp/config/Migrations/20210215015016_CreatePayments.php
@@ -36,7 +36,7 @@ class CreatePayments extends AbstractMigration
         $table->addColumn('discount_id', 'integer', [
             'default' => null,
             'limit' => 11,
-            'null' => false,
+            'null' => true,
         ]);
         $table->addColumn('total_payments', 'integer', [
             'default' => null,

--- a/html/mycakeapp/src/Controller/PaymentsController.php
+++ b/html/mycakeapp/src/Controller/PaymentsController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller;
 
 use App\Controller\AppController;
@@ -13,128 +14,147 @@ use App\Controller\AppController;
 class PaymentsController extends BaseController
 {
 
-    public function initialize()
-    {
-        $this->loadModel('Reservations');
-        $this->loadModel('Tickets');
-        $this->loadModel('Movies');
-        $this->loadModel('Reserved_seats');
-        $this->loadModel('Screening_schedules');
-        $this->loadModel('Users');
-        $this->loadModel('Cards');
-        $this->loadComponent('Auth');
-    }
-    /**
-     * Index method
-     *
-     * @return \Cake\Http\Response|null
-     */
-    public function index()
-    {
-        $this->paginate = [
-            'contain' => ['Reservations', 'Taxes', 'Cards', 'Tickets', 'Discounts'],
-        ];
-        $payments = $this->paginate($this->Payments);
+	public function initialize()
+	{
+		$this->loadModel('Reservations');
+		$this->loadModel('Tickets');
+		$this->loadModel('Movies');
+		$this->loadModel('Reserved_seats');
+		$this->loadModel('Screening_schedules');
+		$this->loadModel('Users');
+		$this->loadModel('Cards');
+		$this->loadComponent('Auth');
+	}
+	/**
+	 * Index method
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	public function index()
+	{
+		$this->paginate = [
+			'contain' => ['Reservations', 'Taxes', 'Cards', 'Tickets', 'Discounts'],
+		];
+		$payments = $this->paginate($this->Payments);
 
-        $this->set(compact('payments'));
-    }
+		$this->set(compact('payments'));
+	}
 
-    /**
-     * View method
-     *
-     * @param string|null $id Payment id.
-     * @return \Cake\Http\Response|null
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
-     */
-    public function view($id = null)
-    {
-        $payment = $this->Payments->get($id, [
-            'contain' => ['Reservations', 'Taxes', 'Cards', 'Tickets', 'Discounts'],
-        ]);
+	/**
+	 * View method
+	 *
+	 * @param string|null $id Payment id.
+	 * @return \Cake\Http\Response|null
+	 * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+	 */
+	public function view($id = null)
+	{
+		$payment = $this->Payments->get($id, [
+			'contain' => ['Reservations', 'Taxes', 'Cards', 'Tickets', 'Discounts'],
+		]);
 
-        $this->set('payment', $payment);
-    }
+		$this->set('payment', $payment);
+	}
 
-    /**
-     * Add method
-     *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
-     */
-    public function add()
-    {
-        $payment = $this->Payments->newEntity();
-        if ($this->request->is('post')) {
-            $payment = $this->Payments->patchEntity($payment, $this->request->getData());
-            if ($this->Payments->save($payment)) {
-                $this->Flash->success(__('The payment has been saved.'));
+	/**
+	 * Add method
+	 *
+	 * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+	 */
+	public function add()
+	{
+		$payment = $this->Payments->newEntity();
+		if ($this->request->is('post')) {
+			$payment = $this->Payments->patchEntity($payment, $this->request->getData());
+			if ($this->Payments->save($payment)) {
+				$this->Flash->success(__('The payment has been saved.'));
 
-                return $this->redirect(['action' => 'index']);
-            }
-            $this->Flash->error(__('The payment could not be saved. Please, try again.'));
-        }
-        $reservations = $this->Payments->Reservations->find('list', ['limit' => 200]);
-        $taxes = $this->Payments->Taxes->find('list', ['limit' => 200]);
-        $cards = $this->Payments->Cards->find('list', ['limit' => 200]);
-        $tickets = $this->Payments->Tickets->find('list', ['limit' => 200]);
-        $discounts = $this->Payments->Discounts->find('list', ['limit' => 200]);
-        $this->set(compact('payment', 'reservations', 'taxes', 'cards', 'tickets', 'discounts'));
-    }
+				return $this->redirect(['action' => 'index']);
+			}
+			$this->Flash->error(__('The payment could not be saved. Please, try again.'));
+		}
+		$reservations = $this->Payments->Reservations->find('list', ['limit' => 200]);
+		$taxes = $this->Payments->Taxes->find('list', ['limit' => 200]);
+		$cards = $this->Payments->Cards->find('list', ['limit' => 200]);
+		$tickets = $this->Payments->Tickets->find('list', ['limit' => 200]);
+		$discounts = $this->Payments->Discounts->find('list', ['limit' => 200]);
+		$this->set(compact('payment', 'reservations', 'taxes', 'cards', 'tickets', 'discounts'));
+	}
 
-    /**
-     * Edit method
-     *
-     * @param string|null $id Payment id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
-     */
-    public function edit($id = null)
-    {
-        $payment = $this->Payments->get($id, [
-            'contain' => [],
-        ]);
-        if ($this->request->is(['patch', 'post', 'put'])) {
-            $payment = $this->Payments->patchEntity($payment, $this->request->getData());
-            if ($this->Payments->save($payment)) {
-                $this->Flash->success(__('The payment has been saved.'));
+	/**
+	 * Edit method
+	 *
+	 * @param string|null $id Payment id.
+	 * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+	 * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+	 */
+	public function edit($id = null)
+	{
+		$payment = $this->Payments->get($id, [
+			'contain' => [],
+		]);
+		if ($this->request->is(['patch', 'post', 'put'])) {
+			$payment = $this->Payments->patchEntity($payment, $this->request->getData());
+			if ($this->Payments->save($payment)) {
+				$this->Flash->success(__('The payment has been saved.'));
 
-                return $this->redirect(['action' => 'index']);
-            }
-            $this->Flash->error(__('The payment could not be saved. Please, try again.'));
-        }
-        $reservations = $this->Payments->Reservations->find('list', ['limit' => 200]);
-        $taxes = $this->Payments->Taxes->find('list', ['limit' => 200]);
-        $cards = $this->Payments->Cards->find('list', ['limit' => 200]);
-        $tickets = $this->Payments->Tickets->find('list', ['limit' => 200]);
-        $discounts = $this->Payments->Discounts->find('list', ['limit' => 200]);
-        $this->set(compact('payment', 'reservations', 'taxes', 'cards', 'tickets', 'discounts'));
-    }
+				return $this->redirect(['action' => 'index']);
+			}
+			$this->Flash->error(__('The payment could not be saved. Please, try again.'));
+		}
+		$reservations = $this->Payments->Reservations->find('list', ['limit' => 200]);
+		$taxes = $this->Payments->Taxes->find('list', ['limit' => 200]);
+		$cards = $this->Payments->Cards->find('list', ['limit' => 200]);
+		$tickets = $this->Payments->Tickets->find('list', ['limit' => 200]);
+		$discounts = $this->Payments->Discounts->find('list', ['limit' => 200]);
+		$this->set(compact('payment', 'reservations', 'taxes', 'cards', 'tickets', 'discounts'));
+	}
 
-    /**
-     * Delete method
-     *
-     * @param string|null $id Payment id.
-     * @return \Cake\Http\Response|null Redirects to index.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
-     */
-    public function delete($id = null)
-    {
-        $this->request->allowMethod(['post', 'delete']);
-        $payment = $this->Payments->get($id);
-        if ($this->Payments->delete($payment)) {
-            $this->Flash->success(__('The payment has been deleted.'));
-        } else {
-            $this->Flash->error(__('The payment could not be deleted. Please, try again.'));
-        }
+	/**
+	 * Delete method
+	 *
+	 * @param string|null $id Payment id.
+	 * @return \Cake\Http\Response|null Redirects to index.
+	 * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+	 */
+	public function delete($id = null)
+	{
+		$this->request->allowMethod(['post', 'delete']);
+		$payment = $this->Payments->get($id);
+		if ($this->Payments->delete($payment)) {
+			$this->Flash->success(__('The payment has been deleted.'));
+		} else {
+			$this->Flash->error(__('The payment could not be deleted. Please, try again.'));
+		}
 
-        return $this->redirect(['action' => 'index']);
-    }
+		return $this->redirect(['action' => 'index']);
+	}
 
-    public function payment()
-    {
-        $this->viewBuilder()->setLayout('main');
-        $authuser = $this->Auth->user('id');
-        //ログインユーザーのカードを登録した順番で取得
-        $cards = $this->Cards->find('all', array('order' => array('Cards.created ASC')))->where(['user_id' => $authuser]);
-        $this->set(compact('cards'));
-    }
+	public function payment()
+	{
+		$this->viewBuilder()->setLayout('main');
+		$session = $this->getRequest()->getSession();
+		$authuser = $this->Auth->user('id');
+		//ログインユーザーのカードを登録した順番で取得
+		$cards = $this->Cards->find('all', array('order' => array('Cards.created ASC')))->where(['user_id' => $authuser]);
+
+		if ($this->request->is('post')) {
+			//ラジオボタンで選択したクレジットカードIDを取得
+			$selected_card_id = $this->request->getData('card');
+			if (isset($selected_card_id)) {
+				$session->write('session.card_id', $selected_card_id);
+				return $this->redirect(['action' => 'paymentsummary']);
+			} else {
+				$error = 'クレジットカードを選択してください';
+				$this->set(compact('error'));
+			}
+		}
+		$this->set(compact('cards'));
+		$session->consume('session.card_id');
+	}
+
+	public function paymentSummary()
+	{
+		$this->viewBuilder()->setLayout('main');
+	}
 }

--- a/html/mycakeapp/src/Controller/PaymentsController.php
+++ b/html/mycakeapp/src/Controller/PaymentsController.php
@@ -208,7 +208,7 @@ class PaymentsController extends BaseController
 		$session->consume('session.reservations_id');
 		$session->consume('session.reserved_seats_id');
 		$session->consume('session.screening_schedules_id');
-		$session->consume('session.ticket');
+		$session->consume('session.ticket_id');
 		$session->consume('session.card_id');
 	}
 }

--- a/html/mycakeapp/src/Controller/PaymentsController.php
+++ b/html/mycakeapp/src/Controller/PaymentsController.php
@@ -163,10 +163,7 @@ class PaymentsController extends BaseController
 		$session = $this->getRequest()->getSession();
 		$payments = $this->Payments->newEntity();
 		$this->viewBuilder()->setLayout('main');
-		// $authuser = $this->Auth->user('id');
-		$session_ticket_id = $this->getRequest()->getSession()->read('session.ticket');
-		// var_dump($ticket_id);
-		// exit;
+		$session_ticket_id = $this->getRequest()->getSession()->read('session.ticket_id');
 		$tickets = $this->Tickets->find()->where(['id' => $session_ticket_id]);
 		$price = $tickets->toArray()[0]->price;
 		//消費税を検索し、100で割る

--- a/html/mycakeapp/src/Controller/PaymentsController.php
+++ b/html/mycakeapp/src/Controller/PaymentsController.php
@@ -10,8 +10,20 @@ use App\Controller\AppController;
  *
  * @method \App\Model\Entity\Payment[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
  */
-class PaymentsController extends AppController
+class PaymentsController extends BaseController
 {
+
+    public function initialize()
+    {
+        $this->loadModel('Reservations');
+        $this->loadModel('Tickets');
+        $this->loadModel('Movies');
+        $this->loadModel('Reserved_seats');
+        $this->loadModel('Screening_schedules');
+        $this->loadModel('Users');
+        $this->loadModel('Cards');
+        $this->loadComponent('Auth');
+    }
     /**
      * Index method
      *
@@ -115,5 +127,14 @@ class PaymentsController extends AppController
         }
 
         return $this->redirect(['action' => 'index']);
+    }
+
+    public function payment()
+    {
+        $this->viewBuilder()->setLayout('main');
+        $authuser = $this->Auth->user('id');
+        //ログインユーザーのカードを登録した順番で取得
+        $cards = $this->Cards->find('all', array('order' => array('Cards.created ASC')))->where(['user_id' => $authuser]);
+        $this->set(compact('cards'));
     }
 }

--- a/html/mycakeapp/src/Controller/PaymentsController.php
+++ b/html/mycakeapp/src/Controller/PaymentsController.php
@@ -23,6 +23,7 @@ class PaymentsController extends BaseController
 		$this->loadModel('Screening_schedules');
 		$this->loadModel('Users');
 		$this->loadModel('Cards');
+		$this->loadModel('Taxes');
 		$this->loadComponent('Auth');
 	}
 	/**
@@ -156,5 +157,23 @@ class PaymentsController extends BaseController
 	public function paymentSummary()
 	{
 		$this->viewBuilder()->setLayout('main');
+		$authuser = $this->Auth->user('id');
+		$ticket_id = $this->getRequest()->getSession()->read('session.ticket');
+		$tickets = $this->Tickets->find()->where(['id' => $ticket_id]);
+		$price = $tickets->toArray()[0]->price;
+		//消費税を検索し、100で割る
+		$tax = $this->Taxes->find()->where(['is_deleted' => 0 ]);
+		$tax_rate = ($tax->toArray()[0]->tax_rate)/100;
+		$sales_tax = $price * $tax_rate;
+		$total = $price + ($price * $tax_rate);
+
+
+
+
+
+
+
+		$this->set(compact('price','sales_tax','total'));
+
 	}
 }

--- a/html/mycakeapp/src/Controller/PaymentsController.php
+++ b/html/mycakeapp/src/Controller/PaymentsController.php
@@ -24,6 +24,7 @@ class PaymentsController extends BaseController
 		$this->loadModel('Users');
 		$this->loadModel('Cards');
 		$this->loadModel('Taxes');
+		$this->loadModel('Payments');
 		$this->loadComponent('Auth');
 	}
 	/**
@@ -157,15 +158,28 @@ class PaymentsController extends BaseController
 	public function paymentSummary()
 	{
 		$this->viewBuilder()->setLayout('main');
-		$authuser = $this->Auth->user('id');
+		// $authuser = $this->Auth->user('id');
 		$ticket_id = $this->getRequest()->getSession()->read('session.ticket');
 		$tickets = $this->Tickets->find()->where(['id' => $ticket_id]);
 		$price = $tickets->toArray()[0]->price;
 		//消費税を検索し、100で割る
 		$tax = $this->Taxes->find()->where(['is_deleted' => 0 ]);
 		$tax_rate = ($tax->toArray()[0]->tax_rate)/100;
-		$sales_tax = $price * $tax_rate;
-		$total = $price + ($price * $tax_rate);
+		$sales_tax = $price * $tax_rate;//料金に対しての消費税額
+		$total = $price + ($price * $tax_rate);//合計金額
+		if ($this->request->is('post')) {
+			$payments = $this->Payments->newEntity();
+
+
+			// $data = array(
+			// 	'reservation_id' => $reservations_id[0]['id'],
+			// 	'screening_schedule_id' => $session_screening_schedule_id,
+			// 	'seat' => $seatNum[0],);
+
+
+
+			// return $this->redirect([ 'action' => 'confirm']);
+		}
 
 
 
@@ -173,7 +187,20 @@ class PaymentsController extends BaseController
 
 
 
-		$this->set(compact('price','sales_tax','total'));
+		$this->set(compact('price','sales_tax','total','payments'));
 
 	}
+
+	public function confirm()
+	{
+		// $session = $this->getRequest()->getSession();
+		// if (!$session->read('session.signup')) {
+		// 	throw new InternalErrorException;
+		// }
+
+		$this->viewBuilder()->setLayout('main');
+		// $session->consume('session.signup');
+	}
+
+
 }

--- a/html/mycakeapp/src/Controller/ReservationsController.php
+++ b/html/mycakeapp/src/Controller/ReservationsController.php
@@ -177,7 +177,7 @@ class ReservationsController extends BaseController
 		$session_reserved_seats_id = $session->read('session.reserved_seats_id');
 		//上の行で取得したidでreserved_seatsテーブルの情報を取得
 		$reserved_seats = $this->Reserved_seats->find()->where(['id' => $session_reserved_seats_id]);
-		$this->set(compact('tickets', 'screening_schedules', 'movie', 'reserved_seats','cardcount'));
+		$this->set(compact('tickets', 'screening_schedules', 'movie', 'reserved_seats', 'cardcount'));
 	}
 
 	public function dummy()

--- a/html/mycakeapp/src/Controller/ReservationsController.php
+++ b/html/mycakeapp/src/Controller/ReservationsController.php
@@ -21,6 +21,7 @@ class ReservationsController extends BaseController
 		$this->loadModel('Reserved_seats');
 		$this->loadModel('Screening_schedules');
 		$this->loadModel('Users');
+		$this->loadModel('Cards');
 		$this->loadComponent('Auth');
 	}
 
@@ -161,6 +162,9 @@ class ReservationsController extends BaseController
 		$this->viewBuilder()->setLayout('main');
 		$ticket_id = $this->getRequest()->getSession()->read('session.ticket');
 		$tickets = $this->Tickets->find()->where(['id' => $ticket_id]);
+		$authuser = $this->Auth->user('id');
+		//カードの枚数を数えて、ビューでの分岐に使う
+		$cardcount = $this->Cards->find()->where(['user_id' => $authuser])->count();
 		$session = $this->getRequest()->getSession();
 		//セッションに保存された上映スケジュールidを取得
 		$session_screening_schedule_id = $session->read('session.screening_schedule');
@@ -173,7 +177,7 @@ class ReservationsController extends BaseController
 		$session_reserved_seats_id = $session->read('session.reserved_seats');
 		//上の行で取得したidでreserved_seatsテーブルの情報を取得
 		$reserved_seats = $this->Reserved_seats->find()->where(['id' => $session_reserved_seats_id]);
-		$this->set(compact('tickets', 'screening_schedule', 'movie', 'reserved_seats'));
+		$this->set(compact('tickets', 'screening_schedule', 'movie', 'reserved_seats','cardcount'));
 	}
 
 	public function dummy()

--- a/html/mycakeapp/src/Controller/ReservationsController.php
+++ b/html/mycakeapp/src/Controller/ReservationsController.php
@@ -130,14 +130,14 @@ class ReservationsController extends BaseController
 		$tickets = $this->Tickets->find('all', array('order' => array('Tickets.row ASC')));
 		$session = $this->getRequest()->getSession();
 		//セッションに保存された上映スケジュールidを取得
-		$session_screening_schedule_id = $session->read('session.screening_schedule');
+		$session_screening_schedule_id = $session->read('session.screening_schedules_id');
 		//取得した上映スケジュールidで検索、レコードの情報を取得
-		$screening_schedule = $this->Screening_schedules->find()->where(['id' => $session_screening_schedule_id]);
+		$screening_schedules = $this->Screening_schedules->find()->where(['id' => $session_screening_schedule_id]);
 		//上映スケジュールのmovie_idの値でmoviesテーブルを検索
-		$screening_schedule_movie_id = $screening_schedule->toArray()[0]->movie_id;
-		$movie = $this->Movies->find()->where(['id' => $screening_schedule_movie_id]);
+		$screening_schedules_movie_id = $screening_schedules->toArray()[0]->movie_id;
+		$movie = $this->Movies->find()->where(['id' => $screening_schedules_movie_id]);
 		//セッションに保存された座席予約のidを取得
-		$session_reserved_seats_id = $session->read('session.reserved_seats');
+		$session_reserved_seats_id = $session->read('session.reserved_seats_id');
 		//上の行で取得したidでreserved_seatsテーブルの情報を取得
 		$reserved_seats = $this->Reserved_seats->find()->where(['id' => $session_reserved_seats_id]);
 
@@ -153,7 +153,7 @@ class ReservationsController extends BaseController
 				$this->set(compact('error'));
 			}
 		}
-		$this->set(compact('tickets', 'screening_schedule', 'movie', 'reserved_seats'));
+		$this->set(compact('tickets', 'screening_schedules', 'movie', 'reserved_seats'));
 		$session->consume('session.ticket');
 	}
 
@@ -167,34 +167,38 @@ class ReservationsController extends BaseController
 		$cardcount = $this->Cards->find()->where(['user_id' => $authuser])->count();
 		$session = $this->getRequest()->getSession();
 		//セッションに保存された上映スケジュールidを取得
-		$session_screening_schedule_id = $session->read('session.screening_schedule');
+		$session_screening_schedule_id = $session->read('session.screening_schedules_id');
 		//取得した上映スケジュールidで検索、レコードの情報を取得
-		$screening_schedule = $this->Screening_schedules->find()->where(['id' => $session_screening_schedule_id]);
+		$screening_schedules = $this->Screening_schedules->find()->where(['id' => $session_screening_schedule_id]);
 		//上映スケジュールのmovie_idの値でmoviesテーブルを検索
-		$screening_schedule_movie_id = $screening_schedule->toArray()[0]->movie_id;
-		$movie = $this->Movies->find()->where(['id' => $screening_schedule_movie_id]);
+		$screening_schedules_movie_id = $screening_schedules->toArray()[0]->movie_id;
+		$movie = $this->Movies->find()->where(['id' => $screening_schedules_movie_id]);
 		//セッションに保存された座席予約のidを取得
-		$session_reserved_seats_id = $session->read('session.reserved_seats');
+		$session_reserved_seats_id = $session->read('session.reserved_seats_id');
 		//上の行で取得したidでreserved_seatsテーブルの情報を取得
 		$reserved_seats = $this->Reserved_seats->find()->where(['id' => $session_reserved_seats_id]);
-		$this->set(compact('tickets', 'screening_schedule', 'movie', 'reserved_seats','cardcount'));
+		$this->set(compact('tickets', 'screening_schedules', 'movie', 'reserved_seats','cardcount'));
 	}
 
 	public function dummy()
 	{
-		$reserved_seats = $this->Reserved_seats->find()->first();
+		$authuser = $this->Auth->user('id');
+		$reservations = $this->Reservations->find()->where(['user_id' => $authuser])->first();
+		$reserved_seats = $this->Reserved_seats->find()->where(['reservation_id' => $reservations['id']])->first();
 		//座席予約テーブルのスケジュールIDでスケジュールテーブルを検索
-		$screening_schedule = $this->Screening_schedules->find()->where(['id' => $reserved_seats['screening_schedule_id']])->first();
+		$screening_schedules = $this->Screening_schedules->find()->where(['id' => $reserved_seats['screening_schedule_id']])->first();
 		$session = $this->getRequest()->getSession();
 		$this->viewBuilder()->setLayout('main');
 		//次へボタンを押した時にセッションに保存をしてリダイレクト
 		if ($this->request->is('post')) {
-			$session->write('session.reserved_seats', $reserved_seats['id']);
-			$session->write('session.screening_schedule', $screening_schedule['id']);
+			$session->write('session.reservations_id', $reservations['id']);
+			$session->write('session.reserved_seats_id', $reserved_seats['id']);
+			$session->write('session.screening_schedules_id', $screening_schedules['id']);
 			return $this->redirect(['action' => 'selectticket']);
 		}
 		//画面遷移してきたタイミングで保存していたセッションは破棄する
-		$session->consume('session.seats');
-		$session->consume('session.screening_schedule');
+		$session->consume('session.reservations_id');
+		$session->consume('session.reserved_seats_id');
+		$session->consume('session.screening_schedules_id');
 	}
 }

--- a/html/mycakeapp/src/Controller/ReservationsController.php
+++ b/html/mycakeapp/src/Controller/ReservationsController.php
@@ -144,9 +144,9 @@ class ReservationsController extends BaseController
 		//次へのボタンを押した時の処理
 		if ($this->request->is('put')) {
 			//ラジオボタンで選択したチケットIDを取得
-			$selected_ticket = $this->request->getData('ticket');
+			$selected_ticket = $this->request->getData('ticket_id');
 			if (isset($selected_ticket)) {
-				$session->write('session.ticket', $selected_ticket);
+				$session->write('session.ticket_id', $selected_ticket);
 				return $this->redirect(['action' => 'reservation']);
 			} else {
 				$error = 'チケットを選択してください';
@@ -154,13 +154,13 @@ class ReservationsController extends BaseController
 			}
 		}
 		$this->set(compact('tickets', 'screening_schedules', 'movie', 'reserved_seats'));
-		$session->consume('session.ticket');
+		$session->consume('session.ticket_id');
 	}
 
 	public function reservation()
 	{
 		$this->viewBuilder()->setLayout('main');
-		$ticket_id = $this->getRequest()->getSession()->read('session.ticket');
+		$ticket_id = $this->getRequest()->getSession()->read('session.ticket_id');
 		$tickets = $this->Tickets->find()->where(['id' => $ticket_id]);
 		$authuser = $this->Auth->user('id');
 		//カードの枚数を数えて、ビューでの分岐に使う

--- a/html/mycakeapp/src/Template/Payments/confirm.ctp
+++ b/html/mycakeapp/src/Template/Payments/confirm.ctp
@@ -1,0 +1,8 @@
+<?= $this->Html->css('Users/confirm.css') ?>
+<div class="content-area">
+  <h3>予約完了</h3>
+  <p>決済が完了しました。</p>
+  <div class="btn">
+    <?= $this->Html->link("マイページに戻る", ['controller' => 'Main', 'action' => 'mypage']) ?>
+  </div>
+</div>

--- a/html/mycakeapp/src/Template/Payments/confirm.ctp
+++ b/html/mycakeapp/src/Template/Payments/confirm.ctp
@@ -1,8 +1,8 @@
 <?= $this->Html->css('Users/confirm.css') ?>
 <div class="content-area">
-  <h3>予約完了</h3>
-  <p>決済が完了しました。</p>
-  <div class="btn">
-    <?= $this->Html->link("マイページに戻る", ['controller' => 'Main', 'action' => 'mypage']) ?>
-  </div>
+	<h3>予約完了</h3>
+	<p>決済が完了しました。</p>
+	<div class="btn">
+		<?= $this->Html->link("マイページに戻る", ['controller' => 'Main', 'action' => 'mypage']) ?>
+	</div>
 </div>

--- a/html/mycakeapp/src/Template/Payments/payment.ctp
+++ b/html/mycakeapp/src/Template/Payments/payment.ctp
@@ -4,6 +4,7 @@
 <div class="wrapper">
 	<div class="card-container">
 		<div class="card-info">ご登録のクレジットカード</div>
+		<?= $this->Form->create(null, array('novalidate' => true)); ?>
 		<?php foreach ($cards as $card) : ?>
 			<?php
 			//暗号化したクレジットカード番号を復号
@@ -15,7 +16,14 @@
 			?>
 			<div class="card-area">
 				<div class="card">
-					<div class="card-name"><?= h($card->name) ?></div>
+					<?php echo $this->Form->input('select', array(
+						'hiddenField' => false,
+						'label' => false,
+						"type" => "radio",
+						'options' => array(
+							$card['id'] => $card['name'],
+						)
+					)); ?>
 					<div class="card-number">
 						****-****-****-<span class="number"><?= h($ext_number) ?></span> - 有効期限(月/年) <span><?= $limit_date ?></span>
 					</div>
@@ -24,7 +32,8 @@
 		<?php endforeach; ?>
 	</div>
 	<div class="under-area">
-		<div class="back"><a href="<?= $this->Url->build(['controller' => 'reservations','action' => 'reservation']) ?>">戻る</a></div>
+		<div class="back"><a href="<?= $this->Url->build(['controller' => 'reservations', 'action' => 'reservation']) ?>">戻る</a></div>
 		<?php echo $this->Form->button('確認する', ['label' => false, 'type' => 'submit']); ?>
 	</div>
+	<?= $this->Form->end() ?>
 </div>

--- a/html/mycakeapp/src/Template/Payments/payment.ctp
+++ b/html/mycakeapp/src/Template/Payments/payment.ctp
@@ -16,10 +16,11 @@
 			?>
 			<div class="card-area">
 				<div class="card">
-					<?php echo $this->Form->input('select', array(
+					<?php echo $this->Form->input('card', array(
 						'hiddenField' => false,
 						'label' => false,
 						"type" => "radio",
+						'checked' => "checked",
 						'options' => array(
 							$card['id'] => $card['name'],
 						)
@@ -37,3 +38,6 @@
 	</div>
 	<?= $this->Form->end() ?>
 </div>
+<?php if (isset($error)) : ?>
+	<div class="error">チケットを選択してください</div>
+<?php endif; ?>

--- a/html/mycakeapp/src/Template/Payments/payment.ctp
+++ b/html/mycakeapp/src/Template/Payments/payment.ctp
@@ -1,0 +1,30 @@
+<?= $this->Html->css('payment.css') ?>
+<?php $this->assign("title", "決済方法"); ?>
+
+<div class="wrapper">
+	<div class="card-container">
+		<div class="card-info">ご登録のクレジットカード</div>
+		<?php foreach ($cards as $card) : ?>
+			<?php
+			//暗号化したクレジットカード番号を復号
+			$decryption_number = openssl_decrypt($card['card_number'], 'aes-256-ecb', 'keykeykey');
+			//後ろから4文字を切り取る
+			$ext_number = substr($decryption_number, -4);
+			//有効期限
+			$limit_date = date('m/y', strtotime($card['expiration_date']));
+			?>
+			<div class="card-area">
+				<div class="card">
+					<div class="card-name"><?= h($card->name) ?></div>
+					<div class="card-number">
+						****-****-****-<span class="number"><?= h($ext_number) ?></span> - 有効期限(月/年) <span><?= $limit_date ?></span>
+					</div>
+				</div>
+			</div>
+		<?php endforeach; ?>
+	</div>
+	<div class="under-area">
+		<div class="back"><a href="<?= $this->Url->build(['controller' => 'reservations','action' => 'reservation']) ?>">戻る</a></div>
+		<?php echo $this->Form->button('確認する', ['label' => false, 'type' => 'submit']); ?>
+	</div>
+</div>

--- a/html/mycakeapp/src/Template/Payments/paymentSummary.ctp
+++ b/html/mycakeapp/src/Template/Payments/paymentSummary.ctp
@@ -1,0 +1,10 @@
+<?= $this->Html->css('payment.css') ?>
+<?php $this->assign("title", "決済概要"); ?>
+
+
+<?= $this->Form->create(null, array('novalidate' => true)); ?>
+<div class="under-area">
+	<div class="back"><a href="<?= $this->Url->build(['action' => 'payment']) ?>">戻る</a></div>
+	<?php echo $this->Form->button('決済する', ['label' => false, 'type' => 'submit']); ?>
+</div>
+<?= $this->Form->end() ?>

--- a/html/mycakeapp/src/Template/Payments/paymentSummary.ctp
+++ b/html/mycakeapp/src/Template/Payments/paymentSummary.ctp
@@ -1,9 +1,35 @@
 <?= $this->Html->css('payment.css') ?>
 <?php $this->assign("title", "決済概要"); ?>
-
-
+<div class="payments">
+	<div class="list">
+		<div class="summary">
+			<div class="item">
+				<div>チケット金額(税抜)</div>
+				<div>&yen1800</div>
+			</div>
+			<div class="item point">
+				<div>ご利用ポイント</div>
+				<div>pt</div>
+			</div>
+			<div class="underline"></div>
+			<div class="item">
+				<div>小計</div>
+				<div>&yen1500</div>
+			</div>
+			<div class="item">
+				<div>消費税</div>
+				<div>&yen</div>
+			</div>
+			<div class="underline"></div>
+			<div class="item">
+				<div>合計(税込)</div>
+				<div>&yen</div>
+			</div>
+		</div>
+	</div>
+</div>
 <?= $this->Form->create(null, array('novalidate' => true)); ?>
-<div class="under-area">
+<div class="under-area-summary">
 	<div class="back"><a href="<?= $this->Url->build(['action' => 'payment']) ?>">戻る</a></div>
 	<?php echo $this->Form->button('決済する', ['label' => false, 'type' => 'submit']); ?>
 </div>

--- a/html/mycakeapp/src/Template/Payments/paymentSummary.ctp
+++ b/html/mycakeapp/src/Template/Payments/paymentSummary.ctp
@@ -5,7 +5,7 @@
 		<div class="summary">
 			<div class="item">
 				<div>チケット金額(税抜)</div>
-				<div>&yen1800</div>
+				<div>&yen<?= number_format($price)  ?></div>
 			</div>
 			<div class="item point">
 				<div>ご利用ポイント</div>
@@ -14,16 +14,17 @@
 			<div class="underline"></div>
 			<div class="item">
 				<div>小計</div>
-				<div>&yen1500</div>
+				<!-- 利用ポイントの計算は現時点ではしない -->
+				<div>&yen<?= number_format($price) ?></div>
 			</div>
 			<div class="item">
 				<div>消費税</div>
-				<div>&yen</div>
+				<div>&yen<?= number_format($sales_tax) ?></div>
 			</div>
 			<div class="underline"></div>
 			<div class="item">
 				<div>合計(税込)</div>
-				<div>&yen</div>
+				<div>&yen<?= number_format($total) ?></div>
 			</div>
 		</div>
 	</div>

--- a/html/mycakeapp/src/Template/Reservations/reservation.ctp
+++ b/html/mycakeapp/src/Template/Reservations/reservation.ctp
@@ -32,6 +32,10 @@ $week_name = ['日', '月', '火', '水', '木', '金', '土'];
 	<?= $this->Form->create(null, array('novalidate' => true)); ?>
 	<div class="under-area">
 		<div class="back"><a href="<?= $this->Url->build(['action' => 'selectticket']) ?>">戻る</a></div>
-		<?php echo $this->Form->button('決済へ', ['label' => false, 'type' => 'submit']); ?>
+		<?php if ($cardcount  >= 1) : ?>
+			<div class="next"><a href="<?= $this->Url->build(['controller' => 'payments', 'action' => 'payment']) ?>">決済へ</a></div>
+		<?php else : ?>
+			<div class="next"><a href="<?= $this->Url->build(['controller' => 'Cards', 'action' => 'credit']) ?>">決済へ</a></div>
+		<?php endif; ?>
 	</div>
 	<?= $this->Form->end() ?>

--- a/html/mycakeapp/src/Template/Reservations/reservation.ctp
+++ b/html/mycakeapp/src/Template/Reservations/reservation.ctp
@@ -3,9 +3,9 @@
 <?php
 //データの読み込み
 $title = $movie->toArray()[0]->title;
-$date = $screening_schedule->toArray()[0]->screening_date;
-$start_time = $screening_schedule->toArray()[0]->start_time;
-$end_time = $screening_schedule->toArray()[0]->end_time;
+$date = $screening_schedules->toArray()[0]->screening_date;
+$start_time = $screening_schedules->toArray()[0]->start_time;
+$end_time = $screening_schedules->toArray()[0]->end_time;
 $seat = $reserved_seats->toArray()[0]->seat;
 //曜日に変換するための配列
 $week_name = ['日', '月', '火', '水', '木', '金', '土'];

--- a/html/mycakeapp/src/Template/Reservations/selectTicket.ctp
+++ b/html/mycakeapp/src/Template/Reservations/selectTicket.ctp
@@ -25,7 +25,7 @@ $week_name = ['日', '月', '火', '水', '木', '金', '土'];
 	<div class="ticket">
 		<?php foreach ($tickets as $ticket) : ?>
 			<div class="ticket-area">
-				<?php echo $this->Form->control('ticket', array(
+				<?php echo $this->Form->control('ticket_id', array(
 					'hiddenField' => false,
 					'label' => false,
 					"type" => "radio",

--- a/html/mycakeapp/src/Template/Reservations/selectTicket.ctp
+++ b/html/mycakeapp/src/Template/Reservations/selectTicket.ctp
@@ -3,9 +3,9 @@
 <?php
 //データの読み込み
 $title = $movie->toArray()[0]->title;
-$date = $screening_schedule->toArray()[0]->screening_date;
-$start_time = $screening_schedule->toArray()[0]->start_time;
-$end_time = $screening_schedule->toArray()[0]->end_time;
+$date = $screening_schedules->toArray()[0]->screening_date;
+$start_time = $screening_schedules->toArray()[0]->start_time;
+$end_time = $screening_schedules->toArray()[0]->end_time;
 $seat = $reserved_seats->toArray()[0]->seat;
 //曜日に変換するための配列
 $week_name = ['日', '月', '火', '水', '木', '金', '土'];

--- a/html/mycakeapp/webroot/css/payment.css
+++ b/html/mycakeapp/webroot/css/payment.css
@@ -54,6 +54,12 @@
     margin-top: 50px;
 }
 
+.under-area-summary {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+}
+
 .back {
     background-color: #e4dede;
     text-align: center;
@@ -83,6 +89,17 @@
     height: 48px;
     cursor: pointer;
 }
+.under-area-summary button:last-child {
+    color: #ffffff;
+    font-size: 16px;
+    text-align: center;
+    padding: 10px 0;
+    background-color: #f5ae0b;
+    border: 3px solid #f5ae0b;
+    width: 220px;
+    height: 48px;
+    cursor: pointer;
+}
 
 label {
     color: #707070;
@@ -102,4 +119,31 @@ label input {
     text-align: center;
     color: red;
     font-size: 0.9rem;
+}
+
+.payments {
+    padding-top: 50px;
+    display: flex;
+    justify-content: center;
+}
+
+.list {
+    width: 420px;
+    color: #707070;
+    font-size: 1.3rem;
+}
+
+.item {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 30px;
+    margin-bottom: 30px;
+}
+
+.point {
+    color: #f5ae0b;
+}
+
+.underline{
+    border-bottom: 3px solid #e0dede;
 }

--- a/html/mycakeapp/webroot/css/payment.css
+++ b/html/mycakeapp/webroot/css/payment.css
@@ -25,7 +25,8 @@
     border: #b8b5b5 solid 1px;
     border-radius: 8px;
     width: 350px;
-    padding: 20px 20px 20px 40px;
+    padding: 20px 20px 20px 60px;
+    position: relative;
 }
 
 .card-name {
@@ -40,6 +41,7 @@
     color: #707070;
     width: 300px;
     font-size: 0.9rem;
+    margin-top: 10px;
 }
 
 .card-number span {
@@ -80,4 +82,17 @@
     width: 220px;
     height: 48px;
     cursor: pointer;
+}
+
+label {
+    color: #707070;
+    margin-bottom: 20px;
+}
+
+label input {
+    width: 1.4em;
+    height: 1.4em;
+    position: absolute;
+    top: 25px;
+    left: 20px;
 }

--- a/html/mycakeapp/webroot/css/payment.css
+++ b/html/mycakeapp/webroot/css/payment.css
@@ -1,0 +1,83 @@
+.wrapper {
+    padding-top: 50px;
+}
+
+.card-container {
+    width: 500px;
+}
+.card-info {
+    text-align: center;
+    color: #707070;
+    font-size: 0.9rem;
+    margin-bottom: 15px;
+}
+
+.card-area:last-child {
+    padding-top: 25px;
+}
+.card-area {
+    display: flex;
+    justify-content: center;
+    width: 736px;
+}
+
+.card {
+    border: #b8b5b5 solid 1px;
+    border-radius: 8px;
+    width: 350px;
+    padding: 20px 20px 20px 40px;
+}
+
+.card-name {
+    font-size: 1rem;
+    color: #707070;
+    font-weight: bold;
+    margin-bottom: 15px;
+    width: 300px;
+}
+
+.card-number {
+    color: #707070;
+    width: 300px;
+    font-size: 0.9rem;
+}
+
+.card-number span {
+    color: #707070;
+}
+
+.under-area {
+    display: flex;
+    justify-content: center;
+    margin-top: 50px;
+}
+
+.back {
+    background-color: #e4dede;
+    text-align: center;
+    width: 140px;
+    height: 48px;
+    margin-right: 25px;
+}
+
+.back a {
+    color: #707070;
+    text-decoration: none;
+    display: block;
+    height: 48px;
+    line-height: 48px;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.under-area button:last-child {
+    color: #ffffff;
+    font-size: 16px;
+    text-align: center;
+    padding: 10px 0;
+    background-color: #f5ae0b;
+    border: 3px solid #f5ae0b;
+    width: 220px;
+    height: 48px;
+    cursor: pointer;
+}

--- a/html/mycakeapp/webroot/css/payment.css
+++ b/html/mycakeapp/webroot/css/payment.css
@@ -96,3 +96,10 @@ label input {
     top: 25px;
     left: 20px;
 }
+
+.error {
+    margin-top: 15px;
+    text-align: center;
+    color: red;
+    font-size: 0.9rem;
+}

--- a/html/mycakeapp/webroot/css/tickettype.css
+++ b/html/mycakeapp/webroot/css/tickettype.css
@@ -83,6 +83,18 @@
     cursor: pointer;
 }
 
+.under-area button:last-child {
+    color: #ffffff;
+    font-size: 16px;
+    text-align: center;
+    padding: 10px 0;
+    background-color: #f5ae0b;
+    border: 3px solid #f5ae0b;
+    width: 180px;
+    height: 48px;
+    cursor: pointer;
+}
+
 .error {
     margin-top: 15px;
     text-align: center;

--- a/html/mycakeapp/webroot/css/tickettype.css
+++ b/html/mycakeapp/webroot/css/tickettype.css
@@ -57,23 +57,29 @@
 
 .back a {
     color: #707070;
+    font-size: 16px;
     text-decoration: none;
     display: block;
     height: 48px;
     line-height: 48px;
-    font-size: 16px;
     cursor: pointer;
 }
 
-.under-area button:last-child {
-    color: #ffffff;
-    font-size: 16px;
-    text-align: center;
-    padding: 10px 0;
+.next {
     background-color: #f5ae0b;
-    border: 3px solid #f5ae0b;
+    text-align: center;
     width: 180px;
     height: 48px;
+    margin-right: 25px;
+}
+
+.next a {
+    color: #ffffff;
+    font-size: 16px;
+    text-decoration: none;
+    display: block;
+    height: 48px;
+    line-height: 48px;
     cursor: pointer;
 }
 
@@ -84,10 +90,10 @@
     font-size: 0.9rem;
 }
 
-.schedules span{
+.schedules span {
     color: #707070;
 }
 
-.seat span{
+.seat span {
     color: #707070;
 }


### PR DESCRIPTION
**【補足事項】**
・チケット選択の画面から決済完了までつなげて作成しています。
・座席予約のページとはリンクが現状つながっていません。
・screening_schedulesテーブルのdateカラムは後にscreening_dateという名前に変更されるので今回もその体で作っています。レビューの際はscreening_dateに名前を修正してご確認ください。
・screening_schedules、ticket、taxテーブルには何かレコードを入れておいてください。
・エラー画面への遷移処理はできていない箇所があります。時間の関係上、今回は正常系メインで確認をお願いします。
・登録までに座席予約テーブルと予約テーブルに保存したレコードが必要ですので、マージされている予約座席選択画面にて保存処理を行なってください。その後、ダミー画面から確認をお願いします。
・決済登録した後に、マイページからの予約詳細画面に表示がなかったらstart_timeとend_timeのデータ型をdatetimeに変えてみてください。また上映スケジュールが過去のものも表示されないので注意してください
**ダミー画面遷移先**
http://localhost:10380/Reservations/dummy

**確認して欲しい点**
【決済方法ページ】
・カードを登録していない状態でこのページに遷移できないようになっているか
・登録したカードの枚数に応じて表示されているか
・次の画面に遷移した時にセッションにカードのidが保存できているか
【決済概要ページ】
・決済完了した時にセッションが全て消えているか
・消費税や合計金額の表示がただしいか
・DBの登録した登録したレコードの値が正しいか（選択したチケットやカードのidが保存されているか確認をお願いします）

実装で不明な点があれば質問していただければと思います。